### PR TITLE
[SU-43] button iconstyle support

### DIFF
--- a/src/components/Buttons/Button/Button.stories.ts
+++ b/src/components/Buttons/Button/Button.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { IconCatalog } from '@/components';
+import { IconCatalog, IconStyle } from '@/components';
 import { parseIconOptions } from '@/storybook/utils';
 import { Button, ButtonSize, ButtonVariant, HtmlType } from './Button';
 
@@ -50,5 +50,6 @@ export const Twitter: Story = {
     size: ButtonSize.sm,
     variant: ButtonVariant.twitter,
     startIcon: IconCatalog.twitter,
+    iconStyle: IconStyle.light
   },
 };

--- a/src/components/Buttons/Button/Button.tsx
+++ b/src/components/Buttons/Button/Button.tsx
@@ -140,6 +140,11 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    * Elements to display inside the Navbar.
    */
   children?: ReactNode;
+
+  /**
+   * The style for displaying icons in the button. It determines the appearance of the icons, including stroke thickness and fill.
+   */
+  iconStyle?: IconStyle;
 }
 
 /**
@@ -160,6 +165,7 @@ export const Button = ({
   htmlType = HtmlType.button,
   className,
   onClick,
+  iconStyle = IconStyle.light,
   ...restOfProps
 }: ButtonProps) => {
   const setSizes = () => {
@@ -218,14 +224,12 @@ export const Button = ({
       onClick={onClick}
       {...restOfProps}
     >
-      {startIcon && (
-        <Icon className={classes.startIcon} icon={startIcon} iconStyle={IconStyle.light} />
-      )}
+      {startIcon && <Icon className={classes.startIcon} icon={startIcon} iconStyle={iconStyle} />}
       <span>{!isLoading ? children : loadingText}</span>
       {isLoading && (
         <Spinner className="ml-2" variant={SpinnerVariant.neutral} size={SpinnerSize.xs} />
       )}
-      {endIcon && <Icon className={classes.endIcon} icon={endIcon} iconStyle={IconStyle.light} />}
+      {endIcon && <Icon className={classes.endIcon} icon={endIcon} iconStyle={iconStyle} />}
     </button>
   );
 };

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -266,7 +266,7 @@ export interface IconProps {
   icon: IconCatalog;
 
   /**
-   * The style of the icon
+   * The style for displaying icons in the button. It determines the appearance of the icons, including stroke thickness and fill.
    */
   iconStyle?: IconStyle;
 


### PR DESCRIPTION
# **CHECK!!!**
### develop is outdated, needs to be updated, and this PR should be pointed to Develop

## Changes Made 🎉

- [x] feat: Added `iconStyle` prop to the Button Component
- [x] docs: Updated documentation of the Icon Component

### Describe Changes

- Added `iconStyle` prop to the Button Component, allowing users to customize the appearance of icons inside the button.
- Updated documentation for the `iconStyle` prop in the Icon Component, providing clear instructions on how to use this new feature effectively.



## Related Issue(s)

- #43 

## Visuals (Optional)
![firefox_1kG26IxeSy](https://github.com/serudda/side-ui/assets/14036522/638e8621-56bb-4513-9cd3-b58e7aa8665b)


<!--- Add video or images showcasing the changes or demonstrating the functionality --->

## Checklist ✅

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
