### PR TITLE
[SU-52] eslint conflict

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,16 +1,20 @@
+/*eslint no-undef: "off"*/
+
 module.exports = {
   env: {
     browser: true,
-    es2020: true
+    es2020: true,
   },
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended', 'plugin:storybook/recommended'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:storybook/recommended',
+  ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 'latest',
-    sourceType: 'module'
+    sourceType: 'module',
   },
   plugins: ['react-refresh'],
-  rules: {
-    'react-refresh/only-export-components': 'warn'
-  }
 };

--- a/package.json
+++ b/package.json
@@ -45,10 +45,12 @@
     "@popperjs/core": "^2.11.7",
     "@types/lodash.throttle": "^4.1.7",
     "classnames": "^2.3.2",
+    "clsx": "^2.0.0",
     "lodash.throttle": "^4.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-popper": "^2.3.0",
+    "tailwind-merge": "^1.14.0",
     "vite-tsconfig-paths": "^4.2.0"
   },
   "devDependencies": {

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,8 @@
+/*eslint no-undef: "off"*/
+
 module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
-  }
-}
+  },
+};

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,3 +1,5 @@
+/*eslint no-undef: "off"*/
+
 /** @typedef  {import("@ianvs/prettier-plugin-sort-imports").PluginConfig} SortImportsConfig*/
 /** @typedef  {import("prettier").Config} PrettierConfig*/
 /** @typedef  {{ tailwindConfig: string }} TailwindConfig*/

--- a/src/common/utils/cn.ts
+++ b/src/common/utils/cn.ts
@@ -1,0 +1,18 @@
+import { twMerge } from "tailwind-merge";
+import { clsx, ClassValue } from "clsx";
+
+/**
+ * Combines and merges Tailwind CSS classes using twMerge and clsx utility functions.
+ * twMerge is used to handle conflicts between classes effectively.
+ *
+ * @param {...ClassValue} inputs - An array of class values to be combined and merged.
+ * @returns {string} - The merged and combined class names as a string.
+ */
+export const cn = (...inputs: ClassValue[]) => {
+  return twMerge(clsx(inputs))
+}
+
+/**
+ * Source:
+ * Tailwind merge: https://github.com/dcastil/tailwind-merge/tree/v1.14.0
+ */

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -4,4 +4,4 @@ export * from './match';
 export * from './microTask';
 export * from './owner';
 export * from './focusManagement';
-export * from './cn'
+export * from './cn';

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -4,3 +4,4 @@ export * from './match';
 export * from './microTask';
 export * from './owner';
 export * from './focusManagement';
+export * from './cn'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+/*eslint no-undef: "off"*/
+
 module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {


### PR DESCRIPTION
## Changes Made 🎉

- [x] build: added new feature to improve user experience

### Describe Changes

#### Problem
The conflict between the no-undef ESLint rule and ES Modules arises from the difference in how variables and imports are treated between CommonJS (CJS) and ES Modules (ESM).

In CommonJS, the module.exports and require() statements are used to define and import values. The module object is available, and ESLint's no-undef rule is designed to catch references to variables that are not explicitly defined or imported.

However, in ES Modules, variables are scoped differently, and imports are used with the import and export statements. The module object is not available in the same way it is in CommonJS. This difference in scoping and import mechanisms can lead to false positives when using the no-undef rule in an ES Modules context.

#### Solution
Disable the no-undef rule from every config file



## Related Issue(s)

- #52 

## Visuals (Optional)
![Code_2zIEaI8S8O](https://github.com/serudda/side-ui/assets/14036522/10b7bb06-8e48-46b6-93e2-1ec9ba3fd520)

![image](https://github.com/serudda/side-ui/assets/14036522/0ae2bfda-4214-471a-91f0-23593f837fd0)


<!--- Add video or images showcasing the changes or demonstrating the functionality --->

## Checklist ✅

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
