### PR TITLE
[SU-50]  support intellisense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ storybook-static
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  "editor.tabSize": 2,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "todohighlight.keywords": [
+    {
+      "text": "NOTE:",
+      "color": "#FFFFFF",
+      "backgroundColor": "#6D87A4",
+      "overviewRulerColor": "#FFFFFF"
+    }
+  ],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.quickSuggestions": {
+    "strings": true
+  },
+  "editor.formatOnSave": true,
+  "eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "tailwindCSS.classAttributes": ["class", "className", "classes"],
+  "tailwindCSS.experimental.classRegex": [["cn\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]]
+}


### PR DESCRIPTION
## Changes Made 🎉

### Changes Proposed:

- [x] Update `.gitignore` to exclude `vscode/settings.json`
- [x] Introduce `settings.json` configuration with enhanced IntelliSense for the `cn()` function

### Description:

This pull request aims to enhance the Tailwind CSS development experience by improving IntelliSense support for the `cn()` utility function. The changes include two key updates:

1. **Gitignore Update:**
   - The `.gitignore` file is being updated to exclude `vscode/settings.json` from version control. This is to ensure that user-specific or editor-specific settings are not committed to the repository, adhering to best practices.

2. **IntelliSense Enhancement:**
   - Elevate the Tailwind CSS development experience with an intelligent IntelliSense upgrade for the `cn()` utility function, driven by the `settings.json` configuration. This augmentation delivers a more fluid and precise class selection process, fostering swift development while minimizing errors.


## Related Issue(s)

- #50 

## Visuals (Optional)
![Code_LpR2XTZRXa](https://github.com/serudda/side-ui/assets/14036522/ee7a270a-7478-4800-a748-b3b9fcd2830e)


<!--- Add video or images showcasing the changes or demonstrating the functionality --->

## Checklist ✅

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
