### PR TITLE
feat(Image): ✨ add fallback image support and improve error handling

### DIFF
--- a/public/assets/images/alt-avatar.svg
+++ b/public/assets/images/alt-avatar.svg
@@ -1,0 +1,9 @@
+<svg width="150" height="150" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 150 150">
+  <circle cx="75" cy="75" r="75" style="fill:#7f2a61"/>
+
+  <mask id="b" width="114" height="66" x="18" y="99" maskUnits="userSpaceOnUse">
+    <circle cx="75" cy="75" r="75" style="fill:#FFFFFF;"/>
+  </mask>
+  <ellipse fill="00FF00" cx="75" cy="132" class="st3" rx="57" ry="33" style=" fill:#E4C6FA; mask:url(#b)"/>
+  <circle cx="75" cy="63.7" r="27" style="fill:#E4C6FA"/>
+</svg>

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react';
 import { Image } from './Image';
+import type { Meta, StoryObj } from '@storybook/react';
 
 const meta = {
   title: 'UI Components/Image',
@@ -13,5 +13,38 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     src: 'assets/images/default-avatar.svg',
+  },
+};
+
+export const WithFallback: Story = {
+  args: {
+    src: 'BROKEN/default-avatar.svg',
+    fallbackImage: 'assets/images/alt-avatar.svg',
+    alt: 'Fallback Avatar',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Demonstrates using a fallback image when the primary image source fails.',
+      },
+    },
+  },
+};
+
+export const CustomErrorState: Story = {
+  render: (args) => (
+    <Image
+      src="BROKEN/default-avatar.svg"
+      alt="Broken Image"
+      noImg={<div style={{ color: 'red', fontSize: '20px' }}>Image not available</div>}
+      {...args}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows a custom JSX element when both the primary and fallback images fail to load.',
+      },
+    },
   },
 };

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -38,6 +38,12 @@ export interface ImageProps {
   className?: string;
 
   /**
+   * URL of the fallback image to be displayed if the primary image fails
+   * to load.
+   */
+  fallbackImage?: string;
+
+  /**
    * Callback fired when the image load
    */
   onLoad?: (event: React.SyntheticEvent<HTMLImageElement, Event>) => void;
@@ -49,7 +55,12 @@ export interface ImageProps {
  * Created at 2023-08-26
  */
 export const Image = React.forwardRef<HTMLImageElement, ImageProps>(
-  ({ src, srcSet, alt, hasMaxWidth = false, noImg, style, className, onLoad }, ref) => {
+  (
+    { src, srcSet, alt, hasMaxWidth = false, noImg, style, className, onLoad, fallbackImage },
+    ref,
+  ) => {
+    const [imageSrc, setImageSrc] = useState(src);
+    const [hasAttemptedFallback, setHasAttemptedFallback] = useState(false);
     const [imageLoaded, setImageLoaded] = useState(false);
     const [isValidSrc, setIsValidSrc] = useState(Boolean(src));
 
@@ -64,8 +75,15 @@ export const Image = React.forwardRef<HTMLImageElement, ImageProps>(
     );
 
     useEffect(() => {
-      setIsValidSrc(Boolean(src));
-    }, [src]);
+      setIsValidSrc(Boolean(imageSrc));
+    }, [imageSrc]);
+
+    const handleError = (): void => {
+      if (!hasAttemptedFallback && fallbackImage) {
+        setImageSrc(fallbackImage);
+        setHasAttemptedFallback(true);
+      } else setIsValidSrc(false);
+    };
 
     const handleLoad = (event: React.SyntheticEvent<HTMLImageElement, Event>): void => {
       setImageLoaded(true);
@@ -79,11 +97,11 @@ export const Image = React.forwardRef<HTMLImageElement, ImageProps>(
             ref={ref}
             className={classes}
             style={style}
-            src={src}
+            src={imageSrc}
             srcSet={srcSet}
             alt={alt}
             onLoad={handleLoad}
-            onError={(): void => setIsValidSrc(false)}
+            onError={handleError}
           />
         ) : (
           <>

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { cn } from '@common';
 
+export enum ImageLoading {
+  eager = 'eager',
+  lazy = 'lazy',
+}
+
 export interface ImageProps {
   /**
    * URL of the image
@@ -33,6 +38,12 @@ export interface ImageProps {
   style?: React.CSSProperties;
 
   /**
+   * Specifies the loading behavior of the image.
+   * This loading is the equivalent of the loading attribute of the img tag
+   */
+  loading?: ImageLoading;
+
+  /**
    * Specify an optional className to be added to the component
    */
   className?: string;
@@ -56,7 +67,18 @@ export interface ImageProps {
  */
 export const Image = React.forwardRef<HTMLImageElement, ImageProps>(
   (
-    { src, srcSet, alt, hasMaxWidth = false, noImg, style, className, onLoad, fallbackImage },
+    {
+      src,
+      srcSet,
+      alt,
+      hasMaxWidth = false,
+      noImg,
+      style,
+      loading = ImageLoading.eager,
+      className,
+      onLoad,
+      fallbackImage,
+    },
     ref,
   ) => {
     const [imageSrc, setImageSrc] = useState(src);
@@ -102,6 +124,7 @@ export const Image = React.forwardRef<HTMLImageElement, ImageProps>(
             alt={alt}
             onLoad={handleLoad}
             onError={handleError}
+            loading={loading}
           />
         ) : (
           <>


### PR DESCRIPTION
## Changes Made 🎉

- [x] feat(Image): ✨ add fallback image support and improve error handling
- [x] feat(Image): 🚀 implement `loading` attribute for lazy loading support

### Describe Changes

This PR introduces two significant enhancements to the Image component. First, a `fallbackImage` prop has been added, allowing a secondary image source to be specified. This fallback image is used when the primary image source fails to load, providing a smoother user experience by ensuring that an image is always displayed. Additionally, the component's error handling logic has been enhanced. If both the primary and fallback image sources fail, the component can now display a custom JSX element designated by the `noImg` prop or a default error state. 

The second enhancement introduces support for the `loading` attribute, enabling browser-native lazy loading of images. This feature further improves the component's performance and usability, particularly on pages with a large number of images or in scenarios where network bandwidth is a concern.

These changes collectively improve the component's resilience, usability, and performance, particularly in scenarios with unreliable image sources or network conditions.

## Visuals (Optional)

#### Example
The visuals below showcase the enhanced error handling and the new lazy loading feature in action, providing guidance on using the component:

![image](https://github.com/serudda/side-ui/assets/14036522/226fc49e-4e3b-4160-ab00-f9f6aebf3887)

- The second image showcases the component's error handling: the first three images load successfully from their `src`, while the last three switch to a fallback due to broken `src` paths. The third image demonstrates the component's final error state: the first three images load correctly, but the last three, with both `src` and fallback failing, display the `noImg` element, highlighting the component's comprehensive error management.

![image](https://github.com/serudda/side-ui/assets/14036522/0eefd3c2-3c3b-4092-9866-0c446b381378)

- The third image illustrates advanced error handling: while the first three images load correctly, the last three—having both `src` and `fallbackImage` fail—trigger the `noImg` display, demonstrating the component's ability to maintain a user-friendly interface even when all image sources fail.

![image](https://github.com/serudda/side-ui/assets/14036522/bfb06112-ac68-4c78-98de-59c3839188be)

<!--- Add video or images showcasing the changes or demonstrating the functionality --->

## Checklist ✅

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
