### PR TITLE
fix(breadcrumbs): 🐛  add unique keys to breadcrumb items for optimize…

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { Children, ReactNode, cloneElement, isValidElement, useState } from 'react';
+import { Children, Fragment, ReactNode, cloneElement, isValidElement, useState } from 'react';
 import { cn } from '@common';
 import { CollapseDropdown, CollapsedSpread } from '@components';
 import {
@@ -125,6 +125,7 @@ export const Breadcrumbs = ({
     child: ReactNode,
     separator: string | ReactNode,
     identifier: BreadcrumbItemIdentifier,
+    index = 0,
     isFirst = false,
     isLast = false,
     isCollapse = false,
@@ -158,38 +159,41 @@ export const Breadcrumbs = ({
         break;
     }
 
-    return <>{result}</>;
+    return <Fragment key={index}>{result}</Fragment>;
   };
 
-  const beforeCollapseItems: Array<ReactNode> = childrenBeforeCollapse.map((child) =>
-    parseBreadcrumb(child, separator, BreadcrumbItemIdentifier.before, child === firstItem),
+  const beforeCollapseItems: Array<ReactNode> = childrenBeforeCollapse.map((child, index) =>
+    parseBreadcrumb(child, separator, BreadcrumbItemIdentifier.before, index, child === firstItem),
   );
 
-  const collapseItems: Array<ReactNode> = collapsedChildren.map((child) =>
+  const collapseItems: Array<ReactNode> = collapsedChildren.map((child, index) =>
     parseBreadcrumb(
       child,
       separator,
       BreadcrumbItemIdentifier.collapse,
+      index,
       child === collapseFirstItem,
       child === collapseLastItem,
       collapseMode === CollapseMode.dropdown,
     ),
   );
-  const afterCollapseItems: Array<ReactNode> = childrenAfterCollapse.map((child) =>
+  const afterCollapseItems: Array<ReactNode> = childrenAfterCollapse.map((child, index) =>
     parseBreadcrumb(
       child,
       separator,
       BreadcrumbItemIdentifier.after,
+      index,
       child === afterCollapseFirstItem,
       child === lastItem,
     ),
   );
 
-  const allItems: Array<ReactNode> = childrenArray.map((child) =>
+  const allItems: Array<ReactNode> = childrenArray.map((child, index) =>
     parseBreadcrumb(
       child,
       separator,
       BreadcrumbItemIdentifier.all,
+      index,
       child === firstItem,
       child === lastItem,
     ),


### PR DESCRIPTION
## Changes Made 🎉


- [x] fix: corrected a bug with login functionality


### Describe Changes

The main change involves correcting a bug related to the breadcrumbs rendering in the UI. Previously, breadcrumb items were not assigned unique keys during the rendering process. This omission could lead to inefficient DOM updates and potential rendering issues in React's virtual DOM, especially when the list of breadcrumbs changed dynamically.

To address this issue, I introduced an `index` parameter to the `parseBreadcrumb` function and its calls within the `Breadcrumbs` component. By wrapping each breadcrumb item in a `Fragment` and assigning a unique key based on the item's index, we ensure that React can accurately and efficiently manage the virtual DOM, leading to improved rendering performance and eliminating potential UI glitches.



## Checklist ✅

- [x] My code follows the code style of this project.

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

